### PR TITLE
Added ability to support slices / maps with YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,34 @@ import (
   "github.com/danryan/env"
   "fmt"
   "os"
+  "time"
 )
 
 // An imaginary config for a chat bot
 type Config struct {
-  Name    string `env:"key=NAME required=true"`
-  Port    int    `env:"key=PORT default=9000"`
-  Adapter string `env:"key=ADAPTER default=shell in=shell,slack,hipchat"`
-  Enabled bool   `env:"key=IS_ENABLED default=true"`
+  Name       string              `env:"key=NAME required=true"`
+  Port       int                 `env:"key=PORT default=9000"`
+  Adapter    string              `env:"key=ADAPTER default=shell in=shell,slack,hipchat"`
+  Enabled    bool                `env:"key=IS_ENABLED default=true"`
+  List       []string            `env:"key=LIST decode=yaml default=[]"`
+  MapList    map[string][]string `env:"key=MAP_LIST decode=yaml default={}"`
+  Duration   time.Duration       `env:"key=DURATION decode=type default=5s"`
 }
 
 func main() {
   os.Setenv("NAME", "hal")
+  os.Setenv("LIST", "[a, b, c]")
+  os.Setenv("MAP_LIST", "{a: [A1, A2], b: [B1, B2]}")
+  os.Setenv("DURATION", "60s")
+  
   c := &Config{}
   if err := env.Process(c); err != nil {
     fmt.Println(err)
   }
-  fmt.Printf("name: %s, port: %d, adapter: %s, enabled: %v\n", c.Name, c.Port, c.Adapter, c.Enabled)
+  fmt.Printf("name: %s, port: %d, adapter: %s, enabled: %v, list: %v, maplist: %v, duration: %v\n", c.Name, c.Port, c.Adapter, c.Enabled, c.List, c.MapList, c.Duration)
 }
 // Will print out
-// name: foo, port: 9001, adapter: shell, enabled: true
+// name: foo, port: 9001, adapter: shell, enabled: true, list: [a b c], maplist: map[a:[A1 A2] b:[B1 B2]], duration: 1m0s
 ```
 
 
@@ -43,13 +51,15 @@ This library uses runtime reflection just like `encoding/json`. Most programs wo
 
 ### Supported types
 
-Four types are currently supported:
+Types are currently supported:
 
 * `string` - defaults to `""`
 * `int` - defaults to `0`
 * `bool` - defaults to `false`
 * `float64` - defaults to `0.0`
 * `time.Duration` - defaults to `0`
+* `slice` - defaults to `[]`
+* `map` - defaults to `{}`
 
 Support for custom types via interfaces will likely make an an appearance at a later date.
 
@@ -120,6 +130,46 @@ type Config struct {
   Adapter string `env:"options=shell,slack,hipchat"`
 }
 ```
+
+#### `decode`
+
+Will specify the type of decoding to perform for values from the environment.  If not specified, will by default perform decoding based on `type` and then `kind` if no specific type decoding is found.  
+
+Possible values are:
+
+* `type`
+ * will decode based on the `Type()` of the field 
+* `kind`
+ * will decode based on the `Kind()` of the field 
+* `yaml`
+ * will decode the value with YAML parser 
+
+Allows the ability to parse string values from the environment as YAML, which can then be assigned to complex structures such as slices and maps.
+
+YAML was chosen because it will allow parsing of strings defined with YAML or JSON as JSON is a subset of YAML.   YAML also allows simpler inline definitions of lists and maps as it does not require explicit quotation of keys and values.
+
+```go
+// YAML syntax
+os.Setenv("LIST", "[a,b,c]")
+
+type Config struct {
+	List []string `env:"key=LIST decode=yaml default=[]"`
+}
+
+// ...
+
+// JSON syntax allowed
+os.Setenv("LIST", `["a", "b", "c"]`)
+
+// ...
+
+// By default, slices and maps are decoded with YAML
+type Config struct {
+	List []string `env:"key=LIST"`
+}
+
+```
+
 
 ## Is it any good?
 

--- a/env_test.go
+++ b/env_test.go
@@ -3,6 +3,11 @@ package env
 import (
 	"testing"
 	"time"
+	"fmt"
+	"runtime"
+	"path/filepath"
+	"reflect"
+	"os"
 )
 
 func TestParseDuration(t *testing.T) {
@@ -16,5 +21,198 @@ func TestParseDuration(t *testing.T) {
 
 	if cfg.Duration != time.Second*5 {
 		t.Fatalf("%v != %f ", cfg.Duration, time.Second*5)
+	}
+}
+
+// Test Slice parsing with YAML value
+func TestYamlList(t *testing.T) {
+	os.Setenv("LIST", "[a,b,c]")
+
+	var cfg struct {
+		List        []string `env:"key=LIST decode=yaml default=[]"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.List != nil, "List is nil")
+	assert(t, len(cfg.List) == 3, "List is not length 3")
+	assert(t, cfg.List[0] == "a", "List[0] is not a")
+	assert(t, cfg.List[1] == "b", "List[1] is not b")
+	assert(t, cfg.List[2] == "c", "List[2] is not c")
+}
+
+// Test Map parsing with YAML value
+func TestYamlMap(t *testing.T) {
+	os.Setenv("MAP", "{a: A, b: B}")
+
+	var cfg struct {
+		Map         map[string]string `env:"key=MAP decode=yaml default={}"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.Map != nil, "Map is nil")
+	assert(t, len(cfg.Map) == 2, "Map is not length 2")
+	assert(t, cfg.Map["a"] == "A", "Map[a] is not A")
+	assert(t, cfg.Map["b"] == "B", "Map[b] is not B")
+}
+
+// Test MapSlice parsing with YAML value
+func TestYamlMapList(t *testing.T) {
+	os.Setenv("MAP_LIST", "{a: [A1, A2], b: [B1, B2]}")
+
+	var cfg struct {
+		MapList     map[string][]string `env:"key=MAP_LIST decode=yaml default={}"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.MapList != nil, "MapList is nil")
+	assert(t, len(cfg.MapList) == 2, "MapList is not length 2")
+	assert(t, cfg.MapList["a"][0] == "A1", "MapList[a][0] is not A1")
+	assert(t, cfg.MapList["a"][1] == "A2", "MapList[a][1] is not A2")
+	assert(t, cfg.MapList["b"][0] == "B1", "MapList[b][0] is not B1")
+	assert(t, cfg.MapList["b"][1] == "B2", "MapList[b][1] is not B2")
+}
+
+// Test Slice parsing with JSON value
+func TestJsonList(t *testing.T) {
+	os.Setenv("LIST", `["a","b","c"]`)
+
+	var cfg struct {
+		List        []string `env:"key=LIST decode=yaml default=[]"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.List != nil, "List is nil")
+	assert(t, len(cfg.List) == 3, "List is not length 3")
+	assert(t, cfg.List[0] == "a", "List[0] is not a")
+	assert(t, cfg.List[1] == "b", "List[1] is not b")
+	assert(t, cfg.List[2] == "c", "List[2] is not c")
+}
+
+// Test Map parsing with JSON value
+func TestJsonMap(t *testing.T) {
+	os.Setenv("MAP", `{"a": "A", "b": "B"}`)
+
+	var cfg struct {
+		Map         map[string]string `env:"key=MAP decode=yaml default={}"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.Map != nil, "Map is nil")
+	assert(t, len(cfg.Map) == 2, "Map is not length 2")
+	assert(t, cfg.Map["a"] == "A", "Map[a] is not A")
+	assert(t, cfg.Map["b"] == "B", "Map[b] is not B")
+}
+// Test MapSlice parsing with JSON
+func TestJsonMapList(t *testing.T) {
+	os.Setenv("MAP_LIST", `{"a": ["A1", "A2"], "b": ["B1", "B2"]}`)
+
+	var cfg struct {
+		MapList     map[string][]string `env:"key=MAP_LIST decode=yaml default={}"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.MapList != nil, "MapList is nil")
+	assert(t, len(cfg.MapList) == 2, "MapList is not length 2")
+	assert(t, cfg.MapList["a"][0] == "A1", "MapList[a][0] is not A1")
+	assert(t, cfg.MapList["a"][1] == "A2", "MapList[a][1] is not A2")
+	assert(t, cfg.MapList["b"][0] == "B1", "MapList[b][0] is not B1")
+	assert(t, cfg.MapList["b"][1] == "B2", "MapList[b][1] is not B2")
+}
+
+// Test Slice parsing with no decode specified (default)
+// Should accept YAML
+func TestDefaultList(t *testing.T) {
+	os.Setenv("LIST", "[a,b,c]")
+
+	var cfg struct {
+		List        []string `env:"key=LIST default=[]"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.List != nil, "List is nil")
+	assert(t, len(cfg.List) == 3, "List is not length 3")
+	assert(t, cfg.List[0] == "a", "List[0] is not a")
+	assert(t, cfg.List[1] == "b", "List[1] is not b")
+	assert(t, cfg.List[2] == "c", "List[2] is not c")
+}
+
+// Test Map parsing with no decode specified (default)
+// Should accept YAML
+func TestDefaultMap(t *testing.T) {
+	os.Setenv("MAP", "{a: A, b: B}")
+
+	var cfg struct {
+		Map         map[string]string `env:"key=MAP default={}"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.Map != nil, "Map is nil")
+	assert(t, len(cfg.Map) == 2, "Map is not length 2")
+	assert(t, cfg.Map["a"] == "A", "Map[a] is not A")
+	assert(t, cfg.Map["b"] == "B", "Map[b] is not B")
+}
+
+// Test MapSlice parsing with no decode specified (default)
+// Should accept YAML
+func TestDefaultMapList(t *testing.T) {
+	os.Setenv("MAP_LIST", "{a: [A1, A2], b: [B1, B2]}")
+
+	var cfg struct {
+		MapList     map[string][]string `env:"key=MAP_LIST default={}"`
+	}
+
+	err := Process(&cfg);
+
+	ok(t, err)
+	assert(t, cfg.MapList != nil, "MapList is nil")
+	assert(t, len(cfg.MapList) == 2, "MapList is not length 2")
+	assert(t, cfg.MapList["a"][0] == "A1", "MapList[a][0] is not A1")
+	assert(t, cfg.MapList["a"][1] == "A2", "MapList[a][1] is not A2")
+	assert(t, cfg.MapList["b"][0] == "B1", "MapList[b][0] is not B1")
+	assert(t, cfg.MapList["b"][1] == "B2", "MapList[b][1] is not B2")
+}
+
+// Add some simple funcs to allow quick testing
+// copied from: https://github.com/benbjohnson/testing
+// assert fails the test if the condition is false.
+func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// ok fails the test if an err is not nil.
+func ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// equals fails the test if exp is not equal to act.
+func equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
 	}
 }

--- a/var.go
+++ b/var.go
@@ -8,17 +8,20 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	// YAML not included in golang encode package
+	"gopkg.in/yaml.v2"
 )
 
 // Var struct
 type Var struct {
-	Name     string
-	Key      string
-	Type     reflect.Type
-	Value    reflect.Value
-	Required bool
-	Default  reflect.Value
-	Options  []reflect.Value
+	Name        string
+	Key         string
+	Type        reflect.Type
+	Value       reflect.Value
+	Required    bool
+	Decode      string
+	Default     reflect.Value
+	Options     []reflect.Value
 }
 
 // NewVar returns a new Var
@@ -31,7 +34,7 @@ func NewVarWithFunc(field reflect.StructField, get func(string) string) (*Var, e
 	newVar := &Var{}
 	newVar.Parse(field)
 
-	value, err := convert(newVar.Type, get(newVar.Key))
+	value, err := convert(newVar.Type, get(newVar.Key), newVar.Decode)
 	if err != nil {
 		return newVar, err
 	}
@@ -88,6 +91,10 @@ func (v *Var) SetRequired(value bool) {
 	v.Required = value
 }
 
+func (v *Var) SetDecode(value string) {
+	v.Decode = value
+}
+
 // SetDefault sets Var.Default
 func (v *Var) SetDefault(value reflect.Value) {
 	v.Default = value
@@ -116,6 +123,11 @@ func (v *Var) Parse(field reflect.StructField) error {
 	}
 
 	tagParams := strings.Split(tag, " ")
+
+  // Use a map so we can process in specific order with lookups
+  // Needed to get the decode param processed first
+  tagParamsMap := make(map[string]string)
+
 	for _, tagParam := range tagParams {
 		var key, value string
 
@@ -125,6 +137,19 @@ func (v *Var) Parse(field reflect.StructField) error {
 			value = option[1]
 		}
 
+		tagParamsMap[key] = value
+	}
+
+	// Process the decode tag
+	// Need to be first so we can decode default / options
+	if value, ok := tagParamsMap["decode"]; ok {
+		v.SetDecode(value)
+		// remove the tag as it has been processed
+		delete(tagParamsMap, "decode")
+	}
+
+	// process remaining tags
+	for key, value := range tagParamsMap {
 		switch key {
 		case "key":
 			// override the default key if one is specified
@@ -134,8 +159,12 @@ func (v *Var) Parse(field reflect.StructField) error {
 			// if val != false {
 			v.SetRequired(true)
 			// }
+		// for completeness, but should have been removed already
+		case "decode":
+			// set decode strategy
+			v.SetDecode(value)
 		case "default":
-			d, err := convert(v.Type, value)
+			d, err := convert(v.Type, value, v.Decode)
 			if err != nil {
 				return err
 			}
@@ -145,7 +174,7 @@ func (v *Var) Parse(field reflect.StructField) error {
 			// var values []reflect.Value
 			values := make([]reflect.Value, len(in))
 			for k, val := range in {
-				v1, err := convert(v.Type, val)
+				v1, err := convert(v.Type, val, v.Decode)
 				if err != nil {
 					return err
 				}
@@ -158,32 +187,74 @@ func (v *Var) Parse(field reflect.StructField) error {
 	return nil
 }
 
-// Convert a string into the specified type. Return the type's zero value
-// if we receive an empty string
-func convert(t reflect.Type, value string) (reflect.Value, error) {
+// Convert a string into the specified type.
+// Return the type's zero value if we receive an empty string
+// Use the decode strategy defined
+func convert(t reflect.Type, value string, decode string) (reflect.Value, error) {
 	if value == "" {
 		return reflect.ValueOf(nil), nil
 	}
 
-	var d time.Duration
+	switch decode {
+	// if no decode defined, try with type and then kind
+	// if any type is defined then it will be used else fallback to kind
+	case "":
+		val, err := convertWithType(t, value)
 
-	switch t {
-	case reflect.TypeOf(d):
-		result, err := time.ParseDuration(value)
-		return reflect.ValueOf(result), err
+		if (err != nil) {
+			val, err = convertWithKind(t , value)
+		}
+
+		return val, err
+	case "kind":
+		return convertWithKind(t, value)
+	case "type":
+		return convertWithType(t, value)
+	case "yaml":
+		return convertWithYaml(t, value)
 	default:
+		return reflect.ValueOf(nil), conversionError(decode, `unsupported decode`)
+	}
+}
+
+func convertWithKind(t reflect.Type, value string) (reflect.Value, error) {
+	if value == "" {
+		return reflect.ValueOf(nil), nil
 	}
 
 	switch t.Kind() {
 	case reflect.String:
 		return reflect.ValueOf(value), nil
+		// ptr.Elem()
+		// ptr = reflect.ValueOf(value).Elem().Convert(reflect.String)
+		// return reflect.ValueOf(value), nil
 	case reflect.Int:
 		return parseInt(value)
 	case reflect.Bool:
 		return parseBool(value)
+	case reflect.Slice:
+		return parseSlice(t, value)
+	case reflect.Map:
+		return parseMap(t, value)
 	}
 
 	return reflect.ValueOf(nil), conversionError(value, `unsupported `+t.Kind().String())
+}
+
+func convertWithType(t reflect.Type, value string) (reflect.Value, error) {
+	// Use string value of type to determine type
+	// Avoid declaring temporary vars just to get type
+	switch t.String() {
+	case "time.Duration":
+		result, err := time.ParseDuration(value)
+		return reflect.ValueOf(result), err
+	default:
+		return reflect.ValueOf(nil), conversionError(value, `unsupported type ` + t.String())
+	}
+}
+
+func convertWithYaml(t reflect.Type, value string) (reflect.Value, error) {
+	return parseYaml(t, value)
 }
 
 type errConversion struct {
@@ -227,4 +298,29 @@ func parseFloat(value string) (reflect.Value, error) {
 		return reflect.ValueOf(nil), conversionError(value, "float64")
 	}
 	return reflect.ValueOf(b), nil
+}
+
+// Using YAML syntax by default for slice
+// JSON is a subset of YAML syntax, so both will parse
+func parseSlice(t reflect.Type, value string) (reflect.Value, error) {
+	return parseYaml(t, value)
+}
+
+// Using YAML syntax by default for map
+// JSON is a subset of YAML syntax, so both will parse
+func parseMap(t reflect.Type, value string) (reflect.Value, error) {
+	return parseYaml(t, value)
+}
+
+func parseYaml(t reflect.Type, value string) (reflect.Value, error) {
+	a := reflect.New(t)
+
+	err := yaml.Unmarshal([]byte(value), a.Interface())
+
+	if err != nil {
+		fmt.Print(err)
+		return reflect.ValueOf(nil), conversionError(value, `yaml conversion error; Kind(): ` + t.Kind().String() + `; Type(): ` + t.String())
+	}
+
+	return a.Elem(), nil
 }


### PR DESCRIPTION
Added tag for specifying which decode strategy to use for values. This ultimately allows defining values with YAML syntax and having them decoded into Slice and Map.

Tag is of the the form `decode=<value>`

Support values are:
* type
* kind
* yaml

YAML was chosen because it is a superset of JSON and thus both will parse with the YAML parser. Additionally YAML does not require the explicit quotation of keys and is simpler to write inline strings with. Both represent probably the best ways to define a list / map with inline strings. YAML is not included in the golang:encode package, but the go-yaml project is heavily supported and used.

By default / omission, the Type strategy will be used and then Kind for fallback if that fails. This allows lazy defining the tags and leaving the decode strategy off and if there is a Type defined for decoding it will use it, else use the Kind of the var.

Slices and Maps have been added to the Kind decode strategy. They use their own function which then calls the YAML parse.

Each decoding strategy uses its own function. This keeps each to their single responsibility and eliminates the ambiguity of using multiple decision values in a conversion (mixing Kind and Type).